### PR TITLE
Improve error log message for qemu monitor socket IO 

### DIFF
--- a/src/qemu/qemu_monitor.c
+++ b/src/qemu/qemu_monitor.c
@@ -530,13 +530,14 @@ qemuMonitorIO(GSocket *socket G_GNUC_UNUSED,
     qemuMonitor *mon = opaque;
     bool error = false;
     bool hangup = false;
+    virDomainObj *vm = mon->vm;
 
     virObjectRef(mon);
 
     /* lock access to the monitor and protect fd */
     virObjectLock(mon);
 #if DEBUG_IO
-    VIR_DEBUG("Monitor %p I/O on socket %p cond %d", mon, socket, cond);
+    VIR_DEBUG("Monitor %p I/O on socket %p cond %d vm=%p name=%s", mon, socket, cond, vm, vm->def->name);
 #endif
     if (mon->fd == -1 || !mon->watch) {
         virObjectUnlock(mon);
@@ -583,8 +584,9 @@ qemuMonitorIO(GSocket *socket G_GNUC_UNUSED,
 
         if (!error && !mon->goteof &&
             cond & G_IO_ERR) {
-            virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
-                           _("Invalid file descriptor while waiting for monitor"));
+            virReportError(VIR_ERR_INTERNAL_ERROR,
+                           _("Invalid file descriptor while waiting for monitor vm=%p name=%s"),
+                           vm, vm->def->name);
             mon->goteof = true;
         }
     }
@@ -609,13 +611,14 @@ qemuMonitorIO(GSocket *socket G_GNUC_UNUSED,
             virResetLastError();
         } else {
             if (virGetLastErrorCode() == VIR_ERR_OK && !mon->goteof)
-                virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
-                               _("Error while processing monitor IO"));
+                virReportError(VIR_ERR_INTERNAL_ERROR,
+                               _("Error while processing monitor IO vm=%p name=%s"),
+                               vm, vm->def->name);
             virCopyLastError(&mon->lastError);
             virResetLastError();
         }
 
-        VIR_DEBUG("Error on monitor %s", NULLSTR(mon->lastError.message));
+        VIR_DEBUG("Error on monitor %s vm=%p name=%s", NULLSTR(mon->lastError.message), vm, vm->def->name);
         /* If IO process resulted in an error & we have a message,
          * then wakeup that waiter */
         if (mon->msg && !mon->msg->finished) {
@@ -631,22 +634,20 @@ qemuMonitorIO(GSocket *socket G_GNUC_UNUSED,
      * will try to acquire the virDomainObj *mutex next */
     if (mon->goteof) {
         qemuMonitorEofNotifyCallback eofNotify = mon->cb->eofNotify;
-        virDomainObj *vm = mon->vm;
 
         /* Make sure anyone waiting wakes up now */
         virCondSignal(&mon->notify);
         virObjectUnlock(mon);
-        VIR_DEBUG("Triggering EOF callback");
+        VIR_DEBUG("Triggering EOF callback vm=%p name=%s", vm, vm->def->name);
         (eofNotify)(mon, vm, mon->callbackOpaque);
         virObjectUnref(mon);
     } else if (error) {
         qemuMonitorErrorNotifyCallback errorNotify = mon->cb->errorNotify;
-        virDomainObj *vm = mon->vm;
 
         /* Make sure anyone waiting wakes up now */
         virCondSignal(&mon->notify);
         virObjectUnlock(mon);
-        VIR_DEBUG("Triggering error callback");
+        VIR_DEBUG("Triggering error callback vm=%p name=%s", vm, vm->def->name);
         (errorNotify)(mon, vm, mon->callbackOpaque);
         virObjectUnref(mon);
     } else {
@@ -932,17 +933,19 @@ qemuMonitorSend(qemuMonitor *mon,
                 qemuMonitorMessage *msg)
 {
     int ret = -1;
+    virDomainObj *vm = mon->vm;
 
     /* Check whether qemu quit unexpectedly */
     if (mon->lastError.code != VIR_ERR_OK) {
-        VIR_DEBUG("Attempt to send command while error is set %s",
-                  NULLSTR(mon->lastError.message));
+        VIR_DEBUG("Attempt to send command while error is set %s vm=%p name=%s",
+                  NULLSTR(mon->lastError.message), vm, vm->def->name);
         virSetError(&mon->lastError);
         return -1;
     }
     if (mon->goteof) {
-        virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
-                       _("End of file from qemu monitor"));
+        virReportError(VIR_ERR_INTERNAL_ERROR,
+                       _("End of file from qemu monitor vm=%p name=%s"),
+                       vm, vm->def->name);
         return -1;
     }
 
@@ -955,15 +958,16 @@ qemuMonitorSend(qemuMonitor *mon,
 
     while (!mon->msg->finished) {
         if (virCondWait(&mon->notify, &mon->parent.lock) < 0) {
-            virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
-                           _("Unable to wait on monitor condition"));
+            virReportError(VIR_ERR_INTERNAL_ERROR,
+                           _("Unable to wait on monitor condition vm=%p name=%s"),
+                           vm, vm->def->name);
             goto cleanup;
         }
     }
 
     if (mon->lastError.code != VIR_ERR_OK) {
-        VIR_DEBUG("Send command resulted in error %s",
-                  NULLSTR(mon->lastError.message));
+        VIR_DEBUG("Send command resulted in error %s vm=%p name=%s",
+                  NULLSTR(mon->lastError.message), vm, vm->def->name);
         virSetError(&mon->lastError);
         goto cleanup;
     }


### PR DESCRIPTION
Improve error log message for qemu monitor socket IO by adding VM object and it name.